### PR TITLE
added valuelink.js.map to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "files": [
     "valuelink.js",
+    "valuelink.js.map",
     "valuelink.ts",
     "valuelink.d.ts",
     "tags.jsx",


### PR DESCRIPTION
To fix jspm error:
Error: ENOENT: no such file or directory, open '/path/to/jspm_packages/npm/valuelink@1.3.4/valuelink.js.map'